### PR TITLE
Decouple themes from metadata model

### DIFF
--- a/schema/catalogued_resource_schema.json
+++ b/schema/catalogued_resource_schema.json
@@ -99,21 +99,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": [
-          "Agriculture, fisheries and forestry",
-          "Business, economics and finance",
-          "Crime and justice",
-          "Culture, leisure and sport",
-          "Education",
-          "Energy",
-          "Environment and nature",
-          "Geography",
-          "Government and public sector",
-          "Health and care",
-          "Population and society",
-          "Science and technology",
-          "Transport and infrastructure"
-        ]
+        "maxLength": 50
       }
     },
     "title": {


### PR DESCRIPTION
Update the definition of theme so that instead of specifying the content of the team (and thereby restricting the themes to a set list), the scheme now specifies that the _theme_ will be an array of strings of limited length. 

In effect this change means the schema now says there must be one of more theme strings specified, but leave that control of the actual theme used to the implementation.