### PR TITLE
Extend dataset/distribution to make it more useful when describing APIs

### DIFF
--- a/samples/data_group.json
+++ b/samples/data_group.json
@@ -22,7 +22,7 @@
   ],
   "publisher": "department-for-education",
   "securityClassification": "OFFICIAL",
-  "accessRights": "INTERNAL",
+  "accessRights": "RESTRICTED",
   "hasPart": [
     "431b7a0c-5455-4f03-aeed-1d7829a2107d",
     "57364e40-0523-4183-980f-565cf0cbab6e",

--- a/samples/data_share.json
+++ b/samples/data_share.json
@@ -25,6 +25,6 @@
   ],
   "publisher": "department-for-education",
   "securityClassification": "OFFICIAL",
-  "accessRights": "INTERNAL",
+  "accessRights": "RESTRICTED",
   "relatedResource": "8d085327-21b6-4d8b-9705-88faad231d23"
 }

--- a/samples/dataset.json
+++ b/samples/dataset.json
@@ -28,9 +28,19 @@
   "accessRights": "OPEN",
   "distribution": [
     {
+      "title": "CSV download",
+      "description": "Complete dataset provided as a downloadable file",
       "accessService": ["8d085327-21b6-4d8b-9705-88faad231d23"],
       "downloadURL": "http://example.com/path/to/file.csv",
+      "format": "CSV file",
       "mediaType":["text/csv"]
+    },
+    {
+      "title": "Rest API",
+      "accessURL": "http://example.com/api/",
+      "description": "A fully queryable REST API with JSON and XML output",
+      "format": "API",
+      "title": "Example REST API"
     }
   ]
 }

--- a/schema/dataset_schema.json
+++ b/schema/dataset_schema.json
@@ -25,10 +25,20 @@
             "type": "string",
             "maxLength": 250
           },
+          "description":{
+            "description": "Human readable description of the distribution",
+            "type": "string",
+            "maxLength": 4096
+          },
           "downloadURL": {
             "description": "The location from which the Dataset can be downloaded",
             "type": "string",
             "maxLength": 250
+          },
+          "format": {
+            "description": "Human readable description of the format of the data provided by the distribution",
+            "type": "string",
+            "maxLength": 200
           },
           "mediaType": {
             "description": "The IANA media type, or file format, type, or extention, of the distribution file.",
@@ -37,6 +47,11 @@
               "type": "string",
               "maxLength": 100
             }
+          },
+          "title": {
+            "description": "A title for the distribution",
+            "type": "string",
+            "maxLength": 200
           }
         },
         "required": []


### PR DESCRIPTION
Also updated access rights in a couple of examples to match latest enum.

# Story
### As a Service Owner,
I want the dataset distribution model to include title, description, and format,
So that the Data Marketplace aligns with metadata standards and improves data discoverability.

## Acceptance Criteria:
The dataset distribution model is updated to include the following fields:

- Title: A descriptive title for the dataset distribution.
- Description: A brief explanation of the dataset distribution.
- Format: The file format or access type (e.g., CSV, JSON, API, etc.).

The new fields must be stored and retrievable via API queries.

The fields must be visible in the dataset metadata on the front end.

Ensure compatibility with the DCAT model, as described in [this resource](https://resources.data.gov/resources/dcat-us/#distribution).

Ensure backward compatibility for datasets that do not yet include these fields.

Validate that the changes do not break existing metadata structures or API integrations.