### PR TITLE
Add licence to Catalogued Resource with example

### DIFF
--- a/samples/dataset.json
+++ b/samples/dataset.json
@@ -23,6 +23,10 @@
       "email": "robert.nichols@digital.cabinet-office.gov.uk"
     }
   ],
+  "licence": {
+    "title": "Creative Commons",
+    "licenceURL": "https://creativecommons.org/licenses/by/4.0"
+  },
   "publisher": "academy-for-social-justice",
   "securityClassification": "OFFICIAL",
   "accessRights": "OPEN",
@@ -39,8 +43,14 @@
       "title": "Rest API",
       "accessURL": "http://example.com/api/",
       "description": "A fully queryable REST API with JSON and XML output",
-      "format": "API",
-      "title": "Example REST API"
+      "format": "API"
+    },
+    {
+      "title": "Web Page",
+      "description": "A web page that provides the data, links to downloads, or documentation.",
+      "downloadURL": "http://example.com/path/to/page",
+      "format": "Web page",
+      "mediaType":["text/html"]
     }
   ]
 }

--- a/schema/catalogued_resource_schema.json
+++ b/schema/catalogued_resource_schema.json
@@ -11,7 +11,8 @@
       "enum": [
         "RESTRICTED",
         "OPEN",
-        "COMMERCIAL"
+        "COMMERCIAL",
+        "INTERNAL" // To be removed - temporary assignment to enable transition of existing data
       ]
     },
     "contactPoint": {
@@ -65,6 +66,25 @@
     "issued": {
       "description": "The date the catalogued resource was first made available.",
       "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/shared_schema.json#/schemas/dateOrDateTime"
+    },
+    "licence": {
+      "description": "A legal document under which the resource is made available.",
+      "type": "Object",
+      "properties": {
+        "title": {
+          "description": "Name or title used to label licence",
+          "type": "string",
+          "maxLength": 75
+        },
+        "licenseURL": {
+          "description": "The location of the licence document",
+          "type": "string",
+          "maxLength": 250
+        }
+      },
+      "required": [
+        "licenceURL"
+      ]
     },
     "keyword": {
       "description": "Uncontrolled terms (words or phrases) assigned to describe an information resource.",

--- a/schema/data_group_schema.json
+++ b/schema/data_group_schema.json
@@ -4,7 +4,9 @@
   "$id": "schemas/dataGroup",
   "description": "Metadata schema for a Data group",
   "type": "object",
-  "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/catalogued_resource_schema.json",
+  "allOf":[{
+    "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/catalogued_resource_schema.json"
+  }],
   "properties": {
     "endpointDescription": {
       "description": "A description of the services available via the end-points, including their operations, parameters etc.",

--- a/schema/data_service_schema.json
+++ b/schema/data_service_schema.json
@@ -4,7 +4,9 @@
   "$id": "schemas/dataService",
   "description": "Metadata schema for a Data Service",
   "type": "object",
-  "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/catalogued_resource_schema.json",
+  "allOf":[{
+    "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/catalogued_resource_schema.json"
+  }],
   "properties": {
     "apiType": {
       "description": "The API type.",

--- a/schema/data_share_schema.json
+++ b/schema/data_share_schema.json
@@ -4,7 +4,9 @@
   "$id": "schemas/dataShare",
   "description": "Metadata schema for a Data Share",
   "type": "object",
-  "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/catalogued_resource_schema.json",
+  "allOf":[{
+    "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/catalogued_resource_schema.json"
+  }],
   "properties": {
     "relatedResource": {
       "description": "The identifier of a catalogued resource that is the target of this share request",

--- a/schema/dataset_schema.json
+++ b/schema/dataset_schema.json
@@ -57,10 +57,6 @@
         "required": []
       }
     },
-    "issued": {
-      "description": "The date the data was issued.",
-      "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/shared_schema.json#/schemas/dateOrDateTime"
-    },
     "updateFrequency": {
       "description": "The schedule for how often the data is updated",
       "type": "string"

--- a/schema/dataset_schema.json
+++ b/schema/dataset_schema.json
@@ -4,7 +4,9 @@
   "$id": "schemas/dataset",
   "description": "Metadata schema for a Dataset",
   "type": "object",
-  "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/catalogued_resource_schema.json",
+  "allOf":[{
+    "$ref": "https://co-cddo.github.io/data-catalogue-metadata/schema/catalogued_resource_schema.json"
+  }],
   "properties": {
     "distribution": {
       "description": "A collection of distributions",

--- a/schema/dataset_schema.json
+++ b/schema/dataset_schema.json
@@ -23,7 +23,7 @@
             }
           },
           "accessURL": {
-            "description": "The location from which the Dataset can be accessed",
+            "description": "The location from which the Dataset can be accessed. To be used instead of downloadURL when describing an API",
             "type": "string",
             "maxLength": 250
           },
@@ -33,7 +33,7 @@
             "maxLength": 4096
           },
           "downloadURL": {
-            "description": "The location from which the Dataset can be downloaded",
+            "description": "The location from which the Dataset can be downloaded or Web Page accessed (when mediaType text/html)",
             "type": "string",
             "maxLength": 250
           },


### PR DESCRIPTION
Also:

- Remove issued from Dataset as already defined in Catalogued Resource
- Remove duplicate title from dataset example
- Temporarily reinstate INTERNAL to access rights to allow data transition
- Add example of web page distribution.
- Wrap `$ref` calls to catalogued resource schema in `allOf`. Without this when the schema is pulled into Swagger, all other properties at the same level as the `$ref` call are ignored - which effectively makes everything look like a catalogued resource. For another example of using `allOf` with just a single `$ref`:  https://stackoverflow.com/a/22693428/1014251